### PR TITLE
Fixes regression bug, reported in CMIS-378 re-introduced in CMIS-735.

### DIFF
--- a/atom/cmis/cmis_repository_wrapper.php
+++ b/atom/cmis/cmis_repository_wrapper.php
@@ -506,10 +506,22 @@ class CMISRepositoryWrapper
         $prop_nodes = $xmlnode->getElementsByTagName("object")->item(0)->getElementsByTagName("properties")->item(0)->childNodes;
         foreach ($prop_nodes as $pn)
         {
-        	if ($pn->attributes) {
-				//supressing errors since PHP sometimes sees DOM elements as "non-objects"
-				@$retval->properties[$pn->attributes->getNamedItem("propertyDefinitionId")->nodeValue] = $pn->getElementsByTagName("value")->item(0)->nodeValue;
-			}
+            if ($pn->attributes)
+            {
+                $propDefId = $pn->attributes->getNamedItem("propertyDefinitionId");
+                // TODO: Maybe use ->length=0 to even detect null values
+                if (!is_null($propDefId) && $pn->getElementsByTagName("value") && $pn->getElementsByTagName("value")->item(0))
+                {
+                	if ($pn->getElementsByTagName("value")->length > 1) {
+                		$retval->properties[$propDefId->nodeValue] = array();
+                		for ($idx=0;$idx < $pn->getElementsByTagName("value")->length;$idx++) {
+                			$retval->properties[$propDefId->nodeValue][$idx] = $pn->getElementsByTagName("value")->item($idx)->nodeValue;
+                		}
+                	} else {
+                		$retval->properties[$propDefId->nodeValue] = $pn->getElementsByTagName("value")->item(0)->nodeValue;
+                	}
+                }
+            }
         }
         
         $retval->uuid = $xmlnode->getElementsByTagName("id")->item(0)->nodeValue;

--- a/atom/package.xml
+++ b/atom/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 <package version="1.0">
-	<name>cmis-phplib</name>
+	<name>cmis</name>
 	<summary>PHP Atom Pub CMIS client</summary>
 	<description>
 		This is a PHP CMIS client library that uses the Atom Pub Binding
@@ -16,17 +16,18 @@
 	</maintainers>
 
 	<release>
-		<version>0.2.0</version>
-		<date>2013-11-20</date>
-		<state>stable</state>
+		<version>0.2.0ignos</version>
+		<date>2016-09-29</date>
+		<license>Apache License</license>
+		<state>beta</state>
 		<notes>
-			This is the first published release.
+			This release fixes a regression bug that avoids you to access multivalued properties.
 		</notes>
 		<filelist>
 			<dir name="/" baseinstalldir="cmis-lib">
 				<file role="php" name="cmis-lib.php" />
 			</dir>
-			<dir name="/cmis" baseinstalldir="cmis-lib/cmis">
+			<dir name="/cmis" baseinstalldir="cmis-lib">
 				<file role="php" name="cmis_repository_wrapper.php" />
 				<file role="php" name="cmis_service.php" />
 			</dir>


### PR DESCRIPTION
CMIS-735 re-introduces the bug reported in CMIS-378, so if you use current phpclient code you will not be able to read multi-valued properties.
This request restore the code of CMIS-378 related to matching multi-valued properties.
